### PR TITLE
fix: default effort fallback to medium when effortLevel is missing

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -68,7 +68,7 @@ $usedComma   = Format-Commas $current
 $remainComma = Format-Commas ($size - $current)
 
 # Check reasoning effort
-$effortLevel = "high"
+$effortLevel = "medium"
 if ($env:CLAUDE_CODE_EFFORT_LEVEL) {
     $effortLevel = $env:CLAUDE_CODE_EFFORT_LEVEL
 } else {

--- a/statusline.sh
+++ b/statusline.sh
@@ -77,7 +77,7 @@ remain_comma=$(format_commas $(( size - current )))
 
 # Check reasoning effort
 settings_path="$HOME/.claude/settings.json"
-effort_level="high"
+effort_level="medium"
 if [ -n "$CLAUDE_CODE_EFFORT_LEVEL" ]; then
     effort_level="$CLAUDE_CODE_EFFORT_LEVEL"
 elif [ -f "$settings_path" ]; then


### PR DESCRIPTION
## Summary

This PR fixes the effort fallback shown in the status line when `effortLevel` is not explicitly present in Claude Code settings.

### Changes
- `statusline.sh`: default effort fallback changed from `high` to `medium`
- `statusline.ps1`: default effort fallback changed from `high` to `medium`

## Why

Claude Code only persists `effortLevel` in `settings.json` when the value differs from the default.
When using the default (`medium`), the field is omitted.

Because the script previously defaulted to `high`, users on default settings could see an incorrect `high` effort indicator in the status line.

## Result

When `effortLevel` is absent, the status line now correctly displays `med` (default behavior), unless overridden by:
- `CLAUDE_CODE_EFFORT_LEVEL`, or
- an explicit `effortLevel` in `settings.json`.

Fixes #3