### PR TITLE
chore: add source attribution link to script headers

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,3 +1,5 @@
+# Source: https://github.com/daniel3303/ClaudeCodeStatusLine
+
 $VERSION = "1.2.0"
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Source: https://github.com/daniel3303/ClaudeCodeStatusLine
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 set -f  # disable globbing


### PR DESCRIPTION
## Summary
- Add source repository URL comment to the top of `statusline.ps1` and `statusline.sh`

## Why
When users copy the script into their own dotfiles (e.g. `~/.claude/scripts/`), the original source is lost. A header comment makes it easy to find updates and documentation. I did this for myself and my guess is someone else will like it. Just a nicity 😄 

## Test plan
- [x] Script still outputs expected status line with sample JSON input
- [x] Comment is present at the top of both scripts
- [x] No other lines changed (verified via `git diff`)