### PR TITLE
fix: shorten model name and token count display

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -25,7 +25,11 @@ $reset  = "${esc}[0m"
 
 # Format token counts (e.g., 50k / 200k)
 function Format-Tokens([long]$num) {
-    if ($num -ge 1000000) { return "{0:F1}m" -f ($num / 1000000) }
+    if ($num -ge 1000000) {
+        $val = [math]::Round($num / 1000000, 1)
+        if ([math]::Abs($val - [math]::Round($val)) -lt 0.05) { return "{0:F0}m" -f $val }
+        return "{0:F1}m" -f $val
+    }
     elseif ($num -ge 1000) { return "{0:F0}k" -f ($num / 1000) }
     else { return "$num" }
 }
@@ -63,6 +67,7 @@ function Test-VersionGreaterThan([string]$a, [string]$b) {
 $data = $input | ConvertFrom-Json
 
 $modelName = if ($data.model.display_name) { $data.model.display_name } else { "Claude" }
+$modelName = ($modelName -replace '\s*\((\d+\.?\d*[kKmM])\s+context\)', ' $1').Trim()  # "(1M context)" → "1M"
 
 # Context window
 $size = if ($data.context_window.context_window_size) { [long]$data.context_window.context_window_size } else { 200000 }

--- a/statusline.sh
+++ b/statusline.sh
@@ -26,7 +26,7 @@ reset='\033[0m'
 format_tokens() {
     local num=$1
     if [ "$num" -ge 1000000 ]; then
-        awk "BEGIN {printf \"%.1fm\", $num / 1000000}"
+        awk "BEGIN {v=sprintf(\"%.1f\",$num/1000000)+0; if(v==int(v)) printf \"%dm\",v; else printf \"%.1fm\",v}"
     elif [ "$num" -ge 1000 ]; then
         awk "BEGIN {printf \"%.0fk\", $num / 1000}"
     else
@@ -70,6 +70,7 @@ version_gt() {
 }
 # ===== Extract data from JSON =====
 model_name=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+model_name=$(echo "$model_name" | sed 's/ *(\([0-9.]*[kKmM]*\) context)/ \1/')  # "(1M context)" → "1M"
 
 # Context window
 size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')


### PR DESCRIPTION
## Summary
- Strip verbose parenthetical context labels from model display name  (e.g. "Opus 4.6 (1M context)" → "Opus 4.6 1M") in both `statusline.ps1`  and `statusline.sh`
- Drop trailing `.0` on whole-number million token counts  (e.g. "1.0m" → "1m", "2.0m" → "2m") in both scripts

## Why
The status line has limited horizontal space. The context window size is already shown in the token usage section, so the full "(1M context)" label is redundant. Dropping the `.0` on round millions saves another character.

## Test plan
- [x] Model name: "Opus 4.6 (1M context)" → "Opus 4.6 1M"
- [x] Model name: "Sonnet 4.6 (200k context)" → "Sonnet 4.6 200k"
- [x] Model name: "Opus 4.6 (beta)" → unchanged
- [x] Model name: "Claude" → unchanged
- [x] Tokens: 1,000,000 → "1m" (not "1.0m")
- [x] Tokens: 1,500,000 → "1.5m"
- [x] Tokens: 2,000,000 → "2m"
- [x] Tokens: 50,000 → "50k" (unchanged)
- [x] Verified on both PowerShell and bash
- [x] End-to-end test with sample JSON input