### PR TITLE
fix: use builtin rate_limits from Claude Code JSON input in PowerShell script

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -181,7 +181,17 @@ function Get-OAuthToken {
     return $null
 }
 
-# ===== Usage limits with caching =====
+# ===== Usage limits =====
+# First, try to use rate_limits data provided directly by Claude Code in the JSON input.
+# This is the most reliable source — no OAuth token or API call required.
+$builtinFiveHourPct = $data.rate_limits.five_hour.used_percentage
+$builtinFiveHourReset = $data.rate_limits.five_hour.resets_at
+$builtinSevenDayPct = $data.rate_limits.seven_day.used_percentage
+$builtinSevenDayReset = $data.rate_limits.seven_day.resets_at
+
+$useBuiltin = ($null -ne $builtinFiveHourPct) -or ($null -ne $builtinSevenDayPct)
+
+# Fall back to cached API call only when Claude Code didn't supply rate_limits data
 $cacheDir = Join-Path $env:TEMP "claude"
 $cacheFile = Join-Path $cacheDir "statusline-usage-cache.json"
 $cacheMaxAge = 60  # seconds between API calls
@@ -191,37 +201,45 @@ if (-not (Test-Path $cacheDir)) { New-Item -ItemType Directory -Path $cacheDir -
 $needsRefresh = $true
 $usageData = $null
 
-# Check cache
-if (Test-Path $cacheFile) {
-    $cacheMtime = (Get-Item $cacheFile).LastWriteTime
-    $cacheAge = ((Get-Date) - $cacheMtime).TotalSeconds
-    if ($cacheAge -lt $cacheMaxAge) {
-        $needsRefresh = $false
-        $usageData = Get-Content $cacheFile -Raw
+if (-not $useBuiltin) {
+    # Check cache — shared across all Claude Code instances to avoid rate limits
+    if (Test-Path $cacheFile) {
+        $cacheMtime = (Get-Item $cacheFile).LastWriteTime
+        $cacheAge = ((Get-Date) - $cacheMtime).TotalSeconds
+        if ($cacheAge -lt $cacheMaxAge) {
+            $needsRefresh = $false
+            $usageData = Get-Content $cacheFile -Raw
+        }
     }
-}
 
-# Fetch fresh data if cache is stale
-if ($needsRefresh) {
-    $token = Get-OAuthToken
-    if ($token) {
-        try {
-            $headers = @{
-                "Accept"         = "application/json"
-                "Content-Type"   = "application/json"
-                "Authorization"  = "Bearer $token"
-                "anthropic-beta" = "oauth-2025-04-20"
-                "User-Agent"     = "claude-code/2.1.34"
-            }
-            $response = Invoke-RestMethod -Uri "https://api.anthropic.com/api/oauth/usage" `
-                -Headers $headers -Method Get -TimeoutSec 10 -ErrorAction Stop
-            $usageData = $response | ConvertTo-Json -Depth 10
-            $usageData | Set-Content $cacheFile -Force
-        } catch {}
-    }
-    # Fall back to stale cache
-    if (-not $usageData -and (Test-Path $cacheFile)) {
-        $usageData = Get-Content $cacheFile -Raw
+    # Fetch fresh data if cache is stale
+    if ($needsRefresh) {
+        # Touch cache immediately (stampede lock: prevent parallel instances from fetching simultaneously)
+        if (Test-Path $cacheFile) {
+            (Get-Item $cacheFile).LastWriteTime = Get-Date
+        } else {
+            New-Item -ItemType File -Path $cacheFile -Force | Out-Null
+        }
+        $token = Get-OAuthToken
+        if ($token) {
+            try {
+                $headers = @{
+                    "Accept"         = "application/json"
+                    "Content-Type"   = "application/json"
+                    "Authorization"  = "Bearer $token"
+                    "anthropic-beta" = "oauth-2025-04-20"
+                    "User-Agent"     = "claude-code/2.1.34"
+                }
+                $response = Invoke-RestMethod -Uri "https://api.anthropic.com/api/oauth/usage" `
+                    -Headers $headers -Method Get -TimeoutSec 10 -ErrorAction Stop
+                $usageData = $response | ConvertTo-Json -Depth 10
+                $usageData | Set-Content $cacheFile -Force
+            } catch {}
+        }
+        # Fall back to stale cache
+        if (-not $usageData -and (Test-Path $cacheFile)) {
+            $usageData = Get-Content $cacheFile -Raw
+        }
     }
 }
 
@@ -238,9 +256,41 @@ function Format-ResetTime([string]$isoStr, [string]$style) {
     } catch { return $null }
 }
 
+# Format Unix epoch reset time to compact local time
+function Format-EpochResetTime([object]$epoch, [string]$style) {
+    if ($null -eq $epoch -or "$epoch" -eq "null" -or "$epoch" -eq "") { return $null }
+    try {
+        $dt = [DateTimeOffset]::FromUnixTimeSeconds([long]$epoch).LocalDateTime
+        switch ($style) {
+            "time"     { return $dt.ToString("h:mmtt").ToLower() }
+            "datetime" { return $dt.ToString("MMM d, h:mmtt").ToLower() }
+            default    { return $dt.ToString("MMM d").ToLower() }
+        }
+    } catch { return $null }
+}
+
 $sep = " ${dim}|${reset} "
 
-if ($usageData) {
+if ($useBuiltin) {
+    # ---- Use rate_limits data provided directly by Claude Code in JSON input ----
+    # resets_at values are Unix epoch integers in this source
+    if ($null -ne $builtinFiveHourPct) {
+        $fiveHourPct = [math]::Floor([double]$builtinFiveHourPct)
+        $fiveHourColor = Get-UsageColor $fiveHourPct
+        $out += "${sep}${white}5h${reset} ${fiveHourColor}${fiveHourPct}%${reset}"
+        $fiveHourReset = Format-EpochResetTime $builtinFiveHourReset "time"
+        if ($fiveHourReset) { $out += " ${dim}@${fiveHourReset}${reset}" }
+    }
+
+    if ($null -ne $builtinSevenDayPct) {
+        $sevenDayPct = [math]::Floor([double]$builtinSevenDayPct)
+        $sevenDayColor = Get-UsageColor $sevenDayPct
+        $out += "${sep}${white}7d${reset} ${sevenDayColor}${sevenDayPct}%${reset}"
+        $sevenDayReset = Format-EpochResetTime $builtinSevenDayReset "datetime"
+        if ($sevenDayReset) { $out += " ${dim}@${sevenDayReset}${reset}" }
+    }
+} elseif ($usageData) {
+    # ---- Fall back: API-fetched usage data ----
     try {
         $usage = if ($usageData -is [string]) { $usageData | ConvertFrom-Json } else { $usageData }
 


### PR DESCRIPTION
Fixes the PowerShell script to match the approach already used in the bash script (PR #17).

## Summary
- Read `rate_limits` data directly from the Claude Code JSON input (stdin) as the primary source for 5h/7d usage display in `statusline.ps1`
- Skip the OAuth API call + cache entirely when builtin data is available
- Preserve the existing OAuth API fallback for when `rate_limits` is absent (e.g., before first API response in a new session)
- Handle the Unix epoch format of `resets_at` in the builtin data (vs ISO 8601 in the API response)
- Add stampede lock to the OAuth fallback path to prevent parallel instances from fetching simultaneously

## Why
PR #17 added builtin `rate_limits` support to `statusline.sh` but left `statusline.ps1` still always making the OAuth API call. This means the PowerShell script silently fails when the token is expired/missing/inaccessible, and makes unnecessary API calls even when Claude Code provides the data directly.

## Test plan
- [x] Verify 5h/7d usage displays correctly with builtin `rate_limits` data in the JSON input
- [x] Verify fallback to OAuth API still works when `rate_limits` is absent from input
- [x] Verify empty input returns "Claude" gracefully
- [x] Verified on PowerShell (Windows)