### PR TITLE
fix: fall back to cached usage when API returns zeros

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,6 +1,6 @@
 # Source: https://github.com/daniel3303/ClaudeCodeStatusLine
 
-$VERSION = "1.2.0"
+$VERSION = "1.2.1"
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 # Read input from stdin
@@ -193,7 +193,27 @@ $builtinSevenDayReset = $data.rate_limits.seven_day.resets_at
 
 $useBuiltin = ($null -ne $builtinFiveHourPct) -or ($null -ne $builtinSevenDayPct)
 
-# Fall back to cached API call only when Claude Code didn't supply rate_limits data
+# When builtin values are all zero AND reset timestamps are missing, it likely indicates
+# an API failure on Claude's side — fall through to cached data instead of displaying
+# misleading 0%. Genuine zero responses (after a billing reset) still include valid
+# resets_at timestamps, so we trust those.
+$effectiveBuiltin = $false
+if ($useBuiltin) {
+    # Trust builtin if any percentage is non-zero
+    if (($null -ne $builtinFiveHourPct -and [math]::Floor([double]$builtinFiveHourPct) -ne 0) -or
+        ($null -ne $builtinSevenDayPct -and [math]::Floor([double]$builtinSevenDayPct) -ne 0)) {
+        $effectiveBuiltin = $true
+    }
+    # Also trust if reset timestamps are present — genuine zero responses include valid reset times
+    if (-not $effectiveBuiltin) {
+        if (($null -ne $builtinFiveHourReset -and "$builtinFiveHourReset" -ne "null" -and "$builtinFiveHourReset" -ne "0") -or
+            ($null -ne $builtinSevenDayReset -and "$builtinSevenDayReset" -ne "null" -and "$builtinSevenDayReset" -ne "0")) {
+            $effectiveBuiltin = $true
+        }
+    }
+}
+
+# Cache setup — used as primary source for API path, and as fallback when builtin reports zero
 $cacheDir = Join-Path $env:TEMP "claude"
 $cacheFile = Join-Path $cacheDir "statusline-usage-cache.json"
 $cacheMaxAge = 60  # seconds between API calls
@@ -203,18 +223,18 @@ if (-not (Test-Path $cacheDir)) { New-Item -ItemType Directory -Path $cacheDir -
 $needsRefresh = $true
 $usageData = $null
 
-if (-not $useBuiltin) {
-    # Check cache — shared across all Claude Code instances to avoid rate limits
-    if (Test-Path $cacheFile) {
-        $cacheMtime = (Get-Item $cacheFile).LastWriteTime
-        $cacheAge = ((Get-Date) - $cacheMtime).TotalSeconds
-        if ($cacheAge -lt $cacheMaxAge) {
-            $needsRefresh = $false
-            $usageData = Get-Content $cacheFile -Raw
-        }
+# Always load cache — available as fallback regardless of data source
+if (Test-Path $cacheFile) {
+    $cacheMtime = (Get-Item $cacheFile).LastWriteTime
+    $cacheAge = ((Get-Date) - $cacheMtime).TotalSeconds
+    if ($cacheAge -lt $cacheMaxAge) {
+        $needsRefresh = $false
     }
+    $usageData = Get-Content $cacheFile -Raw
+}
 
-    # Fetch fresh data if cache is stale
+if (-not $effectiveBuiltin) {
+    # Fetch fresh data if cache is stale (shared across all Claude Code instances to avoid rate limits)
     if ($needsRefresh) {
         # Touch cache immediately (stampede lock: prevent parallel instances from fetching simultaneously)
         if (Test-Path $cacheFile) {
@@ -273,7 +293,7 @@ function Format-EpochResetTime([object]$epoch, [string]$style) {
 
 $sep = " ${dim}|${reset} "
 
-if ($useBuiltin) {
+if ($effectiveBuiltin) {
     # ---- Use rate_limits data provided directly by Claude Code in JSON input ----
     # resets_at values are Unix epoch integers in this source
     if ($null -ne $builtinFiveHourPct) {
@@ -291,6 +311,27 @@ if ($useBuiltin) {
         $sevenDayReset = Format-EpochResetTime $builtinSevenDayReset "datetime"
         if ($sevenDayReset) { $out += " ${dim}@${sevenDayReset}${reset}" }
     }
+
+    # Cache builtin values so they're available as fallback when API is unavailable.
+    # Convert epoch resets_at to ISO 8601 for compatibility with the API-format cache parser.
+    # Use invariant culture to avoid locale-dependent decimal separators in JSON.
+    $inv = [System.Globalization.CultureInfo]::InvariantCulture
+    $fhVal = if ($builtinFiveHourPct) { ([double]$builtinFiveHourPct).ToString($inv) } else { "0" }
+    $sdVal = if ($builtinSevenDayPct) { ([double]$builtinSevenDayPct).ToString($inv) } else { "0" }
+    $fhResetJson = "null"
+    if ($null -ne $builtinFiveHourReset -and "$builtinFiveHourReset" -ne "null" -and "$builtinFiveHourReset" -ne "0") {
+        try {
+            $fhResetJson = '"' + [DateTimeOffset]::FromUnixTimeSeconds([long]$builtinFiveHourReset).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") + '"'
+        } catch {}
+    }
+    $sdResetJson = "null"
+    if ($null -ne $builtinSevenDayReset -and "$builtinSevenDayReset" -ne "null" -and "$builtinSevenDayReset" -ne "0") {
+        try {
+            $sdResetJson = '"' + [DateTimeOffset]::FromUnixTimeSeconds([long]$builtinSevenDayReset).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") + '"'
+        } catch {}
+    }
+    $fallbackJson = "{`"five_hour`":{`"utilization`":$fhVal,`"resets_at`":$fhResetJson},`"seven_day`":{`"utilization`":$sdVal,`"resets_at`":$sdResetJson}}"
+    $fallbackJson | Set-Content $cacheFile -Force
 } elseif ($usageData) {
     # ---- Fall back: API-fetched usage data ----
     try {

--- a/statusline.sh
+++ b/statusline.sh
@@ -3,7 +3,7 @@
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 set -f  # disable globbing
-VERSION="1.2.0"
+VERSION="1.2.1"
 
 input=$(cat)
 
@@ -203,7 +203,7 @@ if [ -n "$builtin_five_hour_pct" ] || [ -n "$builtin_seven_day_pct" ]; then
     use_builtin=true
 fi
 
-# Fall back to cached API call only when Claude Code didn't supply rate_limits data
+# Cache setup — shared across all Claude Code instances to avoid rate limits
 claude_config_dir_hash=$(echo -n "$claude_config_dir" | shasum -a 256 2>/dev/null || echo -n "$claude_config_dir" | sha256sum 2>/dev/null)
 claude_config_dir_hash=$(echo "$claude_config_dir_hash" | cut -c1-8)
 cache_file="/tmp/claude/statusline-usage-cache-${claude_config_dir_hash}.json"
@@ -213,19 +213,39 @@ mkdir -p /tmp/claude
 needs_refresh=true
 usage_data=""
 
-if ! $use_builtin; then
-    # Check cache — shared across all Claude Code instances to avoid rate limits
-    if [ -f "$cache_file" ] && [ -s "$cache_file" ]; then
-        cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)
-        now=$(date +%s)
-        cache_age=$(( now - cache_mtime ))
-        if [ "$cache_age" -lt "$cache_max_age" ]; then
-            needs_refresh=false
-        fi
-        usage_data=$(cat "$cache_file" 2>/dev/null)
+# Always load cache — used as primary source for API path, and as fallback when builtin reports zero
+if [ -f "$cache_file" ] && [ -s "$cache_file" ]; then
+    cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)
+    now=$(date +%s)
+    cache_age=$(( now - cache_mtime ))
+    if [ "$cache_age" -lt "$cache_max_age" ]; then
+        needs_refresh=false
     fi
+    usage_data=$(cat "$cache_file" 2>/dev/null)
+fi
 
-    # Fetch fresh data if cache is stale
+# When builtin values are all zero AND reset timestamps are missing, it likely indicates
+# an API failure on Claude's side — fall through to cached data instead of displaying
+# misleading 0%. Genuine zero responses (after a billing reset) still include valid
+# resets_at timestamps, so we trust those.
+effective_builtin=false
+if $use_builtin; then
+    # Trust builtin if any percentage is non-zero
+    if { [ -n "$builtin_five_hour_pct" ] && [ "$(printf '%.0f' "$builtin_five_hour_pct" 2>/dev/null)" != "0" ]; } || \
+       { [ -n "$builtin_seven_day_pct" ] && [ "$(printf '%.0f' "$builtin_seven_day_pct" 2>/dev/null)" != "0" ]; }; then
+        effective_builtin=true
+    fi
+    # Also trust if reset timestamps are present — genuine zero responses include valid reset times
+    if ! $effective_builtin; then
+        if { [ -n "$builtin_five_hour_reset" ] && [ "$builtin_five_hour_reset" != "null" ] && [ "$builtin_five_hour_reset" != "0" ]; } || \
+           { [ -n "$builtin_seven_day_reset" ] && [ "$builtin_seven_day_reset" != "null" ] && [ "$builtin_seven_day_reset" != "0" ]; }; then
+            effective_builtin=true
+        fi
+    fi
+fi
+
+if ! $effective_builtin; then
+    # Fetch fresh data if cache is stale (shared across all Claude Code instances to avoid rate limits)
     if $needs_refresh; then
         touch "$cache_file"  # stampede lock: prevent parallel panes from fetching simultaneously
         token=$(get_oauth_token)
@@ -319,7 +339,7 @@ format_reset_time() {
 
 sep=" ${dim}|${reset} "
 
-if $use_builtin; then
+if $effective_builtin; then
     # ---- Use rate_limits data provided directly by Claude Code in JSON input ----
     # resets_at values are Unix epoch integers in this source
     if [ -n "$builtin_five_hour_pct" ]; then
@@ -341,6 +361,24 @@ if $use_builtin; then
             [ -n "$seven_day_reset" ] && out+=" ${dim}@${seven_day_reset}${reset}"
         fi
     fi
+
+    # Cache builtin values so they're available as fallback when API is unavailable.
+    # Convert epoch resets_at to ISO 8601 for compatibility with the API-format cache parser.
+    _fh_reset_json="null"
+    if [ -n "$builtin_five_hour_reset" ] && [ "$builtin_five_hour_reset" != "null" ] && [ "$builtin_five_hour_reset" != "0" ]; then
+        _fh_iso=$(date -u -r "$builtin_five_hour_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+                  date -u -d "@$builtin_five_hour_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+        [ -n "$_fh_iso" ] && _fh_reset_json="\"$_fh_iso\""
+    fi
+    _sd_reset_json="null"
+    if [ -n "$builtin_seven_day_reset" ] && [ "$builtin_seven_day_reset" != "null" ] && [ "$builtin_seven_day_reset" != "0" ]; then
+        _sd_iso=$(date -u -r "$builtin_seven_day_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+                  date -u -d "@$builtin_seven_day_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+        [ -n "$_sd_iso" ] && _sd_reset_json="\"$_sd_iso\""
+    fi
+    printf '{"five_hour":{"utilization":%s,"resets_at":%s},"seven_day":{"utilization":%s,"resets_at":%s}}' \
+        "${builtin_five_hour_pct:-0}" "$_fh_reset_json" \
+        "${builtin_seven_day_pct:-0}" "$_sd_reset_json" > "$cache_file" 2>/dev/null
 elif [ -n "$usage_data" ] && echo "$usage_data" | jq -e '.five_hour' >/dev/null 2>&1; then
     # ---- Fall back: API-fetched usage data ----
     # ---- 5-hour (current) ----


### PR DESCRIPTION
## Summary

When Claude Code's connection to the Anthropic usage API fails, it sends `used_percentage: 0` for both rate limit windows with no reset timestamps. The status line displayed this as-is ("5h 0%"), misleading users about their actual usage. This PR adds a fallback to the last known good cached data.

## Code changes

- **Cache always loaded** (`statusline.sh`, `statusline.ps1`) — Moved cache reading outside the `if !use_builtin` guard so it's available as fallback even when builtin data is provided.
- **Smart zero detection** — Added `effective_builtin` flag that trusts builtin data only when percentages are non-zero OR valid `resets_at` timestamps are present. Genuine 0% (after billing reset) still includes reset timestamps and is displayed correctly.
- **Builtin-to-cache bridge** — When builtin data is valid, it's saved to the cache file in API-compatible JSON (epoch → ISO conversion for `resets_at`) so future fallbacks have data.
- **PowerShell locale safety** — Uses `InvariantCulture` for numeric formatting and escapes `Z` in .NET date format strings.
- **Version bump** — 1.2.0 → 1.2.1.

## How to test

1. With a working connection: verify usage displays normally (e.g., "5h 42% @14:30")
2. Simulate API failure: provide JSON input with `rate_limits.five_hour.used_percentage: 0` and no `resets_at` → should show last cached value instead of 0%
3. Simulate genuine reset: provide 0% WITH valid `resets_at` timestamps → should show 0% (trusted)
4. First run with no cache and failure input → should show "-" placeholders