### PR TITLE
feat: render new `xhigh` effort level with its own color

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -21,6 +21,7 @@ $green  = "${esc}[38;2;0;160;0m"
 $cyan   = "${esc}[38;2;46;149;153m"
 $red    = "${esc}[38;2;255;85;85m"
 $yellow = "${esc}[38;2;230;200;0m"
+$purple = "${esc}[38;2;167;139;250m"
 $white  = "${esc}[38;2;220;220;220m"
 $dim    = "${esc}[2m"
 $reset  = "${esc}[0m"
@@ -151,6 +152,8 @@ $out += "effort: "
 switch ($effortLevel) {
     "low"    { $out += "${dim}${effortLevel}${reset}" }
     "medium" { $out += "${orange}med${reset}" }
+    "high"   { $out += "${green}${effortLevel}${reset}" }
+    "xhigh"  { $out += "${purple}${effortLevel}${reset}" }
     "max"    { $out += "${red}${effortLevel}${reset}" }
     default  { $out += "${green}${effortLevel}${reset}" }
 }

--- a/statusline.sh
+++ b/statusline.sh
@@ -19,6 +19,7 @@ green='\033[38;2;0;160;0m'
 cyan='\033[38;2;46;149;153m'
 red='\033[38;2;255;85;85m'
 yellow='\033[38;2;230;200;0m'
+purple='\033[38;2;167;139;250m'
 white='\033[38;2;220;220;220m'
 dim='\033[2m'
 reset='\033[0m'
@@ -131,6 +132,8 @@ out+="effort: "
 case "$effort_level" in
     low)    out+="${dim}${effort_level}${reset}" ;;
     medium) out+="${orange}med${reset}" ;;
+    high)   out+="${green}${effort_level}${reset}" ;;
+    xhigh)  out+="${purple}${effort_level}${reset}" ;;
     max)    out+="${red}${effort_level}${reset}" ;;
     *)      out+="${green}${effort_level}${reset}" ;;
 esac


### PR DESCRIPTION
Closes #23.

## Summary

Claude Code v2.1.111 added [`xhigh`](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) as an effort level between `high` and `max` (Opus 4.7 only). Both scripts fall through to the green default, so `xhigh` is indistinguishable from `high`.

This PR adds explicit `high` and `xhigh` cases to the effort switch in both `statusline.sh` and `statusline.ps1`. `xhigh` gets its own color so it's visually distinct from `high` (green) and `max` (red).

## Color choice

I went with purple (`#A78BFA`, `rgb(167, 139, 250)`) for `xhigh` since green (high), red (max), orange (medium), and yellow (usage-50%) are already in the palette, and purple reads well on both dark and light terminals. **Entirely a matter of taste — happy to change it to whatever you prefer** (another shade, a different hue, a symbol prefix like `!xhigh`, etc.).

## Verified

Both scripts tested locally with `CLAUDE_CODE_EFFORT_LEVEL=xhigh` against a mock Claude Code input. Output contains `\033[38;2;167;139;250m` (purple) for `xhigh` and the existing ANSI codes for the other levels.

| level  | color (before)            | color (after)             |
|--------|---------------------------|---------------------------|
| low    | dim                       | dim                       |
| medium | orange (abbrev. `med`)    | orange (abbrev. `med`)    |
| high   | green (via default)       | green (explicit)          |
| xhigh  | **green (via default)** ❌ | **purple (explicit)** ✅  |
| max    | red                       | red                       |

## Test plan

- [x] `CLAUDE_CODE_EFFORT_LEVEL=xhigh bash statusline.sh < mock.json` — emits purple
- [x] `CLAUDE_CODE_EFFORT_LEVEL=xhigh powershell -NoProfile -File statusline.ps1 < mock.json` — emits purple
- [x] Other levels (`low`, `medium`, `high`, `max`) unchanged
- [x] Unknown values still hit the green default branch