### PR TITLE
fix: render extra usage segment + adopt clone-based install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,92 @@
+# Installation
+
+This document is the authoritative install guide. It is written to be executed step-by-step by Claude Code when a user asks to install or update this status line.
+
+## 1. Detect the operating system
+
+- **macOS or Linux** → use `statusline.sh`
+- **Windows** (PowerShell, CMD, Git Bash, or WSL) → use `statusline.ps1`
+
+## 2. Clone the repo
+
+Clone to `~/.claude/statusline/` on Unix, or `%USERPROFILE%\.claude\statusline\` on Windows. If that directory already exists and is a git clone of this repo, run `git pull` in it instead of re-cloning.
+
+**macOS / Linux**
+
+```bash
+git clone https://github.com/daniel3303/ClaudeCodeStatusLine ~/.claude/statusline
+chmod +x ~/.claude/statusline/statusline.sh
+```
+
+**Windows (PowerShell)**
+
+```powershell
+git clone https://github.com/daniel3303/ClaudeCodeStatusLine "$env:USERPROFILE\.claude\statusline"
+```
+
+## 3. Configure `settings.json`
+
+Add (or update) the `statusLine` key in `~/.claude/settings.json` (Unix) or `%USERPROFILE%\.claude\settings.json` (Windows). If the file already contains other keys, merge — do not overwrite.
+
+**macOS / Linux**
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline/statusline.sh"
+  }
+}
+```
+
+**Windows (PowerShell / CMD)**
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -NoProfile -File \"%USERPROFILE%\\.claude\\statusline\\statusline.ps1\""
+  }
+}
+```
+
+**Windows (Git Bash / WSL bash shells)**
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -NoProfile -File \"$USERPROFILE\\.claude\\statusline\\statusline.ps1\""
+  }
+}
+```
+
+> `%VAR%` expands only in CMD/PowerShell; `$VAR` expands only in bash shells. Pick the one that matches the shell Claude Code launches the command in.
+
+## 4. Restart Claude Code
+
+The status line is loaded at startup. After saving `settings.json`, tell the user to restart Claude Code (or start a new session) for the change to take effect.
+
+## Updating
+
+Pull the latest release:
+
+```bash
+git -C ~/.claude/statusline pull
+```
+
+No `settings.json` changes are needed — the command path is stable across versions.
+
+## Uninstalling
+
+1. Remove the `statusLine` block from `settings.json`.
+2. Delete the clone: `rm -rf ~/.claude/statusline` (or the Windows equivalent).
+
+## Requirements
+
+- Claude Code (Pro/Max subscription for rate-limit and extra-usage display)
+- `git` in `PATH`
+- macOS / Linux: `jq` and `curl`
+- Windows: PowerShell 5.1+ (default on Windows 10/11)
+
+If `jq` is missing on macOS/Linux, install it with the system package manager (`brew install jq`, `apt install jq`, etc.).

--- a/README.md
+++ b/README.md
@@ -10,114 +10,65 @@ A custom status line for [Claude Code](https://claude.com/claude-code) that disp
 
 | Segment | Description |
 |---------|-------------|
-| **Model** | Current model name (e.g., Opus 4.6) |
+| **Model** | Current model name (e.g., Opus 4.7) |
 | **CWD@Branch** | Current folder name, git branch, and file changes (+/-) |
 | **Tokens** | Used / total context window tokens (% used) |
-| **Effort** | Reasoning effort level (low, med, high) |
+| **Effort** | Reasoning effort level (low, med, high, xhigh) |
 | **5h** | 5-hour rate limit usage percentage and reset time |
 | **7d** | 7-day rate limit usage percentage and reset time |
 | **Extra** | Extra usage credits spent / limit (if enabled) |
-| **Update** | Clickable link when a new version is available (checked every 24h) |
+| **Update** | Appears when a new version is available (checked every 24h) |
 
 Usage percentages are color-coded: green (<50%) → yellow (≥50%) → orange (≥70%) → red (≥90%).
 
-## Requirements
-
-### macOS / Linux
-
-- `jq` — for JSON parsing
-- `curl` — for fetching usage data from the Anthropic API
-- Claude Code with OAuth authentication (Pro/Max subscription)
-
-### Windows
-
-- PowerShell 5.1+ (included by default on Windows 10/11)
-- `git` in PATH (for branch/diff info)
-- Claude Code with OAuth authentication (Pro/Max subscription)
-
 ## Installation
 
-### Quick setup (recommended)
+### Recommended: clone and let Claude configure it
 
-Copy the contents of `statusline.sh` (or `statusline.ps1` on Windows) and paste it into Claude Code with the prompt:
+Ask Claude Code:
 
-> Use this script as my status bar
+> Clone https://github.com/daniel3303/ClaudeCodeStatusLine and configure it as my status bar.
 
-Claude Code will save the script and configure `settings.json` for you automatically.
+Claude will clone the repo to `~/.claude/statusline/` (or `%USERPROFILE%\.claude\statusline\` on Windows), pick the right script for your OS, and update `settings.json`. Full step-by-step instructions Claude follows live in [INSTALL.md](INSTALL.md).
 
-### Manual setup — macOS / Linux
+Restart Claude Code after Claude saves the configuration.
 
-1. Copy the script to your Claude config directory:
+### Updating
 
-   ```bash
-   cp statusline.sh ~/.claude/statusline.sh
-   chmod +x ~/.claude/statusline.sh
-   ```
+When the status line shows a new release is available, ask Claude:
 
-2. Add the status line config to `~/.claude/settings.json`:
+> Update my status bar.
 
-   ```json
-   {
-     "statusLine": {
-       "type": "command",
-       "command": "~/.claude/statusline.sh"
-     }
-   }
-   ```
+Or update it yourself:
 
-3. Restart Claude Code.
+```bash
+git -C ~/.claude/statusline pull
+```
 
-### Manual setup — Windows
+No `settings.json` changes are needed — the path stays valid across versions.
 
-> **Windows users should use `statusline.ps1`** instead of the bash script.
+### Alternative: paste-install (no git required)
 
-1. Copy the script to your Claude config directory:
+If you can't clone (corporate-locked machine, no git, etc.), copy the contents of `statusline.sh` (macOS / Linux) or `statusline.ps1` (Windows) and paste it into Claude Code with:
 
-   ```powershell
-   Copy-Item statusline.ps1 "$env:USERPROFILE\.claude\statusline.ps1"
-   ```
+> Use this script as my status bar.
 
-2. Add the status line config to `%USERPROFILE%\.claude\settings.json`:
+Claude will save it under `~/.claude/` and wire up `settings.json`. Updating this way requires re-pasting the script on each release.
 
-   **PowerShell / CMD:**
-   ```json
-   {
-     "statusLine": {
-       "type": "command",
-       "command": "powershell -NoProfile -File \"%USERPROFILE%\\.claude\\statusline.ps1\""
-     }
-   }
-   ```
+## Requirements
 
-   **Git Bash / WSL bash:**
-   ```json
-   {
-     "statusLine": {
-       "type": "command",
-       "command": "powershell -NoProfile -File \"$USERPROFILE\\.claude\\statusline.ps1\""
-     }
-   }
-   ```
-
-   > **Note:** Use `%USERPROFILE%` in CMD/PowerShell or `$USERPROFILE` in bash shells. The `%VAR%` syntax does not expand in bash.
-
-3. Restart Claude Code.
+- Claude Code with OAuth authentication (Pro/Max subscription for rate-limit and extra-usage data)
+- `git` in `PATH` (for the recommended install)
+- macOS / Linux: `jq` and `curl`
+- Windows: PowerShell 5.1+ (default on Windows 10/11)
 
 ## Caching
 
-Usage data from the Anthropic API is cached for 60 seconds at `/tmp/claude/statusline-usage-cache.json` to avoid excessive API calls.
+Usage data from the Anthropic API is cached for 60 seconds at `/tmp/claude/statusline-usage-cache-<hash>.json` (or `%TEMP%\claude\...` on Windows). Release checks are cached for 24 hours. Both caches are shared across concurrent Claude Code instances to avoid rate limits.
 
 ## Update Notifications
 
-The status line checks GitHub for new releases once every 24 hours. When a newer version is available, a second line appears below the status line showing the new version and a link to the repository. The check is cached at `/tmp/claude/statusline-version-cache.json` (or `%TEMP%\claude\...` on Windows) and fails silently if the API is unreachable or no release has been published.
-
-## How to Update
-
-When the status line shows an update is available, visit the [repository](https://github.com/daniel3303/ClaudeCodeStatusLine), copy the contents of `statusline.sh` (or `statusline.ps1` on Windows), and paste it into Claude Code with the prompt:
-
-> Use this script as my status bar
-
-Claude Code will replace the script and restart the status line automatically.
+The status line checks GitHub for new releases once every 24 hours. When a newer version is available, a second line appears below the status line. The check fails silently if the API is unreachable.
 
 ## License
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -241,35 +241,40 @@ if (Test-Path $cacheFile) {
     $usageData = Get-Content $cacheFile -Raw
 }
 
-if (-not $effectiveBuiltin) {
-    # Fetch fresh data if cache is stale (shared across all Claude Code instances to avoid rate limits)
-    if ($needsRefresh) {
-        # Touch cache immediately (stampede lock: prevent parallel instances from fetching simultaneously)
-        if (Test-Path $cacheFile) {
-            (Get-Item $cacheFile).LastWriteTime = Get-Date
-        } else {
-            New-Item -ItemType File -Path $cacheFile -Force | Out-Null
-        }
-        $token = Get-OAuthToken
-        if ($token) {
-            try {
-                $headers = @{
-                    "Accept"         = "application/json"
-                    "Content-Type"   = "application/json"
-                    "Authorization"  = "Bearer $token"
-                    "anthropic-beta" = "oauth-2025-04-20"
-                    "User-Agent"     = "claude-code/2.1.34"
-                }
-                $response = Invoke-RestMethod -Uri "https://api.anthropic.com/api/oauth/usage" `
-                    -Headers $headers -Method Get -TimeoutSec 10 -ErrorAction Stop
-                $usageData = $response | ConvertTo-Json -Depth 10
-                $usageData | Set-Content $cacheFile -Force
-            } catch {}
-        }
-        # Fall back to stale cache
-        if (-not $usageData -and (Test-Path $cacheFile)) {
-            $usageData = Get-Content $cacheFile -Raw
-        }
+# Refresh API cache when stale — runs regardless of builtin rate_limits because
+# extra_usage is only exposed through the OAuth usage endpoint (not stdin JSON).
+# Throttled to cacheMaxAge and stampede-locked via touch for shared panes.
+if ($needsRefresh) {
+    # Touch cache immediately (stampede lock: prevent parallel instances from fetching simultaneously)
+    if (Test-Path $cacheFile) {
+        (Get-Item $cacheFile).LastWriteTime = Get-Date
+    } else {
+        New-Item -ItemType File -Path $cacheFile -Force | Out-Null
+    }
+    $token = Get-OAuthToken
+    if ($token) {
+        try {
+            $headers = @{
+                "Accept"         = "application/json"
+                "Content-Type"   = "application/json"
+                "Authorization"  = "Bearer $token"
+                "anthropic-beta" = "oauth-2025-04-20"
+                "User-Agent"     = "claude-code/2.1.34"
+            }
+            $response = Invoke-RestMethod -Uri "https://api.anthropic.com/api/oauth/usage" `
+                -Headers $headers -Method Get -TimeoutSec 10 -ErrorAction Stop
+            $usageData = $response | ConvertTo-Json -Depth 10
+            $usageData | Set-Content $cacheFile -Force
+        } catch {}
+    }
+    # Fall back to stale cache
+    if (-not $usageData -and (Test-Path $cacheFile)) {
+        $usageData = Get-Content $cacheFile -Raw
+    }
+    # Remove the stampede sentinel if the fetch failed to produce valid JSON —
+    # otherwise an empty cache file would suppress retries for a full cacheMaxAge window.
+    if ((Test-Path $cacheFile) -and ((Get-Item $cacheFile).Length -eq 0)) {
+        Remove-Item $cacheFile -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -301,6 +306,39 @@ function Format-EpochResetTime([object]$epoch, [string]$style) {
 
 $sep = " ${dim}|${reset} "
 
+# Render extra_usage segment from API usage data (not available via stdin rate_limits).
+# Returns the segment string (may be empty). No-op when data is missing or is_enabled is false.
+function Format-ExtraUsage($usage) {
+    if (-not $usage) { return "" }
+    try {
+        $enabled = $usage.extra_usage.is_enabled
+        if ($enabled -ne $true) { return "" }
+
+        $pct = [math]::Floor([double](Coalesce $usage.extra_usage.utilization 0))
+        $usedRaw = $usage.extra_usage.used_credits
+        $limitRaw = $usage.extra_usage.monthly_limit
+
+        if ($null -ne $usedRaw -and $null -ne $limitRaw) {
+            $used = "{0:F2}" -f ([double]$usedRaw / 100)
+            $limit = "{0:F2}" -f ([double]$limitRaw / 100)
+            $color = Get-UsageColor $pct
+            return "${sep}${white}extra${reset} ${color}`$${used}/`$${limit}${reset}"
+        } else {
+            return "${sep}${white}extra${reset} ${green}enabled${reset}"
+        }
+    } catch {
+        return ""
+    }
+}
+
+# Parse usage_data once (used by both branches below for extra_usage)
+$parsedUsage = $null
+if ($usageData) {
+    try {
+        $parsedUsage = if ($usageData -is [string]) { $usageData | ConvertFrom-Json } else { $usageData }
+    } catch {}
+}
+
 if ($effectiveBuiltin) {
     # ---- Use rate_limits data provided directly by Claude Code in JSON input ----
     # resets_at values are Unix epoch integers in this source
@@ -320,9 +358,13 @@ if ($effectiveBuiltin) {
         if ($sevenDayReset) { $out += " ${dim}@${sevenDayReset}${reset}" }
     }
 
+    # Render extra_usage from API cache (stdin rate_limits doesn't expose it)
+    $out += Format-ExtraUsage $parsedUsage
+
     # Cache builtin values so they're available as fallback when API is unavailable.
     # Convert epoch resets_at to ISO 8601 for compatibility with the API-format cache parser.
     # Use invariant culture to avoid locale-dependent decimal separators in JSON.
+    # Preserve extra_usage from prior API response so we don't clobber it.
     $inv = [System.Globalization.CultureInfo]::InvariantCulture
     $fhVal = if ($builtinFiveHourPct) { ([double]$builtinFiveHourPct).ToString($inv) } else { "0" }
     $sdVal = if ($builtinSevenDayPct) { ([double]$builtinSevenDayPct).ToString($inv) } else { "0" }
@@ -338,16 +380,20 @@ if ($effectiveBuiltin) {
             $sdResetJson = '"' + [DateTimeOffset]::FromUnixTimeSeconds([long]$builtinSevenDayReset).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") + '"'
         } catch {}
     }
-    $fallbackJson = "{`"five_hour`":{`"utilization`":$fhVal,`"resets_at`":$fhResetJson},`"seven_day`":{`"utilization`":$sdVal,`"resets_at`":$sdResetJson}}"
+    $extraJson = "null"
+    if ($parsedUsage -and $parsedUsage.extra_usage) {
+        try {
+            $extraJson = $parsedUsage.extra_usage | ConvertTo-Json -Depth 5 -Compress
+        } catch {}
+    }
+    $fallbackJson = "{`"five_hour`":{`"utilization`":$fhVal,`"resets_at`":$fhResetJson},`"seven_day`":{`"utilization`":$sdVal,`"resets_at`":$sdResetJson},`"extra_usage`":$extraJson}"
     $fallbackJson | Set-Content $cacheFile -Force
-} elseif ($usageData) {
+} elseif ($parsedUsage) {
     # ---- Fall back: API-fetched usage data ----
     try {
-        $usage = if ($usageData -is [string]) { $usageData | ConvertFrom-Json } else { $usageData }
-
         # ---- 5-hour (current) ----
-        $fiveHourPct = [math]::Floor([double](Coalesce $usage.five_hour.utilization 0))
-        $fiveHourResetIso = $usage.five_hour.resets_at
+        $fiveHourPct = [math]::Floor([double](Coalesce $parsedUsage.five_hour.utilization 0))
+        $fiveHourResetIso = $parsedUsage.five_hour.resets_at
         $fiveHourReset = Format-ResetTime $fiveHourResetIso "time"
         $fiveHourColor = Get-UsageColor $fiveHourPct
 
@@ -355,30 +401,15 @@ if ($effectiveBuiltin) {
         if ($fiveHourReset) { $out += " ${dim}@${fiveHourReset}${reset}" }
 
         # ---- 7-day (weekly) ----
-        $sevenDayPct = [math]::Floor([double](Coalesce $usage.seven_day.utilization 0))
-        $sevenDayResetIso = $usage.seven_day.resets_at
+        $sevenDayPct = [math]::Floor([double](Coalesce $parsedUsage.seven_day.utilization 0))
+        $sevenDayResetIso = $parsedUsage.seven_day.resets_at
         $sevenDayReset = Format-ResetTime $sevenDayResetIso "datetime"
         $sevenDayColor = Get-UsageColor $sevenDayPct
 
         $out += "${sep}${white}7d${reset} ${sevenDayColor}${sevenDayPct}%${reset}"
         if ($sevenDayReset) { $out += " ${dim}@${sevenDayReset}${reset}" }
 
-        # ---- Extra usage ----
-        $extraEnabled = $usage.extra_usage.is_enabled
-        if ($extraEnabled -eq $true) {
-            $extraPct = [math]::Floor([double](Coalesce $usage.extra_usage.utilization 0))
-            $extraUsedRaw = $usage.extra_usage.used_credits
-            $extraLimitRaw = $usage.extra_usage.monthly_limit
-
-            if ($null -ne $extraUsedRaw -and $null -ne $extraLimitRaw) {
-                $extraUsed = "{0:F2}" -f ([double]$extraUsedRaw / 100)
-                $extraLimit = "{0:F2}" -f ([double]$extraLimitRaw / 100)
-                $extraColor = Get-UsageColor $extraPct
-                $out += "${sep}${white}extra${reset} ${extraColor}`$${extraUsed}/`$${extraLimit}${reset}"
-            } else {
-                $out += "${sep}${white}extra${reset} ${green}enabled${reset}"
-            }
-        }
+        $out += Format-ExtraUsage $parsedUsage
     } catch {}
 }
 

--- a/statusline.sh
+++ b/statusline.sh
@@ -248,26 +248,29 @@ if $use_builtin; then
     fi
 fi
 
-if ! $effective_builtin; then
-    # Fetch fresh data if cache is stale (shared across all Claude Code instances to avoid rate limits)
-    if $needs_refresh; then
-        touch "$cache_file"  # stampede lock: prevent parallel panes from fetching simultaneously
-        token=$(get_oauth_token)
-        if [ -n "$token" ] && [ "$token" != "null" ]; then
-            response=$(curl -s --max-time 10 \
-                -H "Accept: application/json" \
-                -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $token" \
-                -H "anthropic-beta: oauth-2025-04-20" \
-                -H "User-Agent: claude-code/2.1.34" \
-                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
-            # Only cache valid usage responses (not error/rate-limit JSON)
-            if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
-                usage_data="$response"
-                echo "$response" > "$cache_file"
-            fi
+# Refresh API cache when stale — runs regardless of builtin rate_limits because
+# extra_usage is only exposed through the OAuth usage endpoint (not stdin JSON).
+# Throttled to cache_max_age and stampede-locked via touch for shared panes.
+if $needs_refresh; then
+    touch "$cache_file"  # stampede lock: prevent parallel panes from fetching simultaneously
+    token=$(get_oauth_token)
+    if [ -n "$token" ] && [ "$token" != "null" ]; then
+        response=$(curl -s --max-time 10 \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $token" \
+            -H "anthropic-beta: oauth-2025-04-20" \
+            -H "User-Agent: claude-code/2.1.34" \
+            "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+        # Only cache valid usage responses (not error/rate-limit JSON)
+        if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
+            usage_data="$response"
+            echo "$response" > "$cache_file"
         fi
     fi
+    # Remove the stampede sentinel if the fetch failed to produce valid JSON —
+    # otherwise an empty cache file would suppress retries for a full cache_max_age window.
+    [ -f "$cache_file" ] && [ ! -s "$cache_file" ] && rm -f "$cache_file"
 fi
 
 # Cross-platform ISO to epoch conversion
@@ -343,6 +346,29 @@ format_reset_time() {
 
 sep=" ${dim}|${reset} "
 
+# Render extra_usage segment from API usage data (not available via stdin rate_limits).
+# Appends to the global $out. No-op when data is missing or is_enabled is false.
+render_extra_usage() {
+    local data="$1"
+    [ -z "$data" ] && return
+    local enabled
+    enabled=$(echo "$data" | jq -r '.extra_usage.is_enabled // false' 2>/dev/null)
+    [ "$enabled" != "true" ] && return
+
+    local pct used limit
+    pct=$(echo "$data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
+    used=$(echo "$data" | jq -r '.extra_usage.used_credits // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
+    limit=$(echo "$data" | jq -r '.extra_usage.monthly_limit // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
+
+    if [ -n "$used" ] && [ -n "$limit" ] && [[ "$used" != *'$'* ]] && [[ "$limit" != *'$'* ]]; then
+        local color
+        color=$(usage_color "$pct")
+        out+="${sep}${white}extra${reset} ${color}\$${used}/\$${limit}${reset}"
+    else
+        out+="${sep}${white}extra${reset} ${green}enabled${reset}"
+    fi
+}
+
 if $effective_builtin; then
     # ---- Use rate_limits data provided directly by Claude Code in JSON input ----
     # resets_at values are Unix epoch integers in this source
@@ -366,8 +392,12 @@ if $effective_builtin; then
         fi
     fi
 
+    # Render extra_usage from API cache (stdin rate_limits doesn't expose it)
+    render_extra_usage "$usage_data"
+
     # Cache builtin values so they're available as fallback when API is unavailable.
     # Convert epoch resets_at to ISO 8601 for compatibility with the API-format cache parser.
+    # Preserve extra_usage from prior API response so we don't clobber it.
     _fh_reset_json="null"
     if [ -n "$builtin_five_hour_reset" ] && [ "$builtin_five_hour_reset" != "null" ] && [ "$builtin_five_hour_reset" != "0" ]; then
         _fh_iso=$(date -u -r "$builtin_five_hour_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
@@ -380,9 +410,12 @@ if $effective_builtin; then
                   date -u -d "@$builtin_seven_day_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
         [ -n "$_sd_iso" ] && _sd_reset_json="\"$_sd_iso\""
     fi
-    printf '{"five_hour":{"utilization":%s,"resets_at":%s},"seven_day":{"utilization":%s,"resets_at":%s}}' \
+    _extra_json=$(echo "$usage_data" | jq -c '.extra_usage // null' 2>/dev/null)
+    [ -z "$_extra_json" ] && _extra_json="null"
+    printf '{"five_hour":{"utilization":%s,"resets_at":%s},"seven_day":{"utilization":%s,"resets_at":%s},"extra_usage":%s}' \
         "${builtin_five_hour_pct:-0}" "$_fh_reset_json" \
-        "${builtin_seven_day_pct:-0}" "$_sd_reset_json" > "$cache_file" 2>/dev/null
+        "${builtin_seven_day_pct:-0}" "$_sd_reset_json" \
+        "$_extra_json" > "$cache_file" 2>/dev/null
 elif [ -n "$usage_data" ] && echo "$usage_data" | jq -e '.five_hour' >/dev/null 2>&1; then
     # ---- Fall back: API-fetched usage data ----
     # ---- 5-hour (current) ----
@@ -403,20 +436,7 @@ elif [ -n "$usage_data" ] && echo "$usage_data" | jq -e '.five_hour' >/dev/null 
     out+="${sep}${white}7d${reset} ${seven_day_color}${seven_day_pct}%${reset}"
     [ -n "$seven_day_reset" ] && out+=" ${dim}@${seven_day_reset}${reset}"
 
-    # ---- Extra usage ----
-    extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
-    if [ "$extra_enabled" = "true" ]; then
-        extra_pct=$(echo "$usage_data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
-        extra_used=$(echo "$usage_data" | jq -r '.extra_usage.used_credits // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
-        extra_limit=$(echo "$usage_data" | jq -r '.extra_usage.monthly_limit // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
-        # Validate: if values are empty or contain unexpanded variables, show simple "enabled" label
-        if [ -n "$extra_used" ] && [ -n "$extra_limit" ] && [[ "$extra_used" != *'$'* ]] && [[ "$extra_limit" != *'$'* ]]; then
-            extra_color=$(usage_color "$extra_pct")
-            out+="${sep}${white}extra${reset} ${extra_color}\$${extra_used}/\$${extra_limit}${reset}"
-        else
-            out+="${sep}${white}extra${reset} ${green}enabled${reset}"
-        fi
-    fi
+    render_extra_usage "$usage_data"
 else
     # No valid usage data — show placeholders
     out+="${sep}${white}5h${reset} ${dim}-${reset}"


### PR DESCRIPTION
## Summary

- Fixes the `extra` segment never rendering once Claude Code began supplying `rate_limits` in the statusline stdin JSON (the common path).
- Makes the OAuth usage-API cache resilient to failed fetches so a transient error does not suppress retries for a full 60s window.
- Updates the install story: leads with "clone the repo, let Claude configure it", adds `INSTALL.md` so Claude has an authoritative step-by-step; paste-install stays as a fallback.

## Code changes

**`statusline.sh` + `statusline.ps1`**
- Removed the `effective_builtin` gate on the usage-API fetch. Claude Code's stdin `rate_limits` only exposes `five_hour` / `seven_day` — `extra_usage` still has to come from `https://api.anthropic.com/api/oauth/usage`.
- Extracted extra-usage rendering into a helper (`render_extra_usage` / `Format-ExtraUsage`) used by both the builtin and API-fallback branches.
- Preserved `.extra_usage` inside the builtin branch's cache snapshot so a freshly fetched value is not clobbered on the next tick.
- Cleaned up the empty stampede-sentinel cache file on failed fetch.
- PowerShell helper is now try/catch-wrapped since the builtin branch has no outer catch.

**`README.md`**
- Install section leads with the clone-and-let-Claude-configure flow; paste-install kept as an alternative.
- Added an "Updating" section showing the single `git pull` path.
- Cache paths updated to reflect the per-config-dir hash suffix.

**`INSTALL.md` (new)**
- OS detection, clone target, per-shell `settings.json` snippets, restart, update, uninstall, requirements.
- Structured to be executed top-to-bottom by Claude Code when a user asks "clone this repo and use it as my status bar".

## How to test

**Fix verification (macOS / Linux)**

1. Wipe the usage cache: `rm -f /tmp/claude/statusline-usage-cache-*.json`
2. Seed a cache entry with `extra_usage.is_enabled=true` to simulate a Pro/Max account with extra credits enabled:
   ```bash
   HASH=$(echo -n "$HOME/.claude" | shasum -a 256 | cut -c1-8)
   echo '{"five_hour":{"utilization":50,"resets_at":"2026-04-30T20:00:00Z"},"seven_day":{"utilization":30,"resets_at":"2026-05-07T20:00:00Z"},"extra_usage":{"is_enabled":true,"utilization":25,"used_credits":1234,"monthly_limit":10000}}' > "/tmp/claude/statusline-usage-cache-${HASH}.json"
   ```
3. Run the script with stdin that includes `rate_limits` (the builtin path):
   ```bash
   echo '{"model":{"display_name":"Claude"},"rate_limits":{"five_hour":{"used_percentage":42,"resets_at":1777777777},"seven_day":{"used_percentage":18,"resets_at":1778888888}}}' | bash statusline.sh
   ```
4. Expect a trailing `| extra $12.34/$100.00` segment. Before this PR, the segment was silently dropped.

**Empty-sentinel cleanup**

1. `rm -f /tmp/claude/statusline-usage-cache-*.json`
2. Run with an invalid token: `CLAUDE_CODE_OAUTH_TOKEN=nope echo '{"model":{"display_name":"C"}}' | bash statusline.sh`
3. Cache file should not exist afterwards (so the next invocation can retry immediately).

**Install docs**

- Open `INSTALL.md` and confirm the `settings.json` snippets match the shell the user is running Claude Code in.
- Dry-run the clone command with `--dry-run` style check: `git ls-remote https://github.com/daniel3303/ClaudeCodeStatusLine` should respond.

## Notes

- Users on Pro/Max without extra usage enabled will now make one call to `/api/oauth/usage` per minute per `CLAUDE_CONFIG_DIR` (previously zero). The endpoint is designed for this cadence and the cache is shared across tmux panes via mtime-based stampede locking.
- VERSION constant left at `1.3.0` — bump and tag a release separately when you want users to see the update-available banner.