### PR TITLE
docs: include clone path in install prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Usage percentages are color-coded: green (<50%) → yellow (≥50%) → orange (
 
 Ask Claude Code:
 
-> Clone https://github.com/daniel3303/ClaudeCodeStatusLine and configure it as my status bar.
+> Clone https://github.com/daniel3303/ClaudeCodeStatusLine to `~/.claude/statusline/` (or `%USERPROFILE%\.claude\statusline\` on Windows) and configure it as my status bar by following its INSTALL.md.
 
-Claude will clone the repo to `~/.claude/statusline/` (or `%USERPROFILE%\.claude\statusline\` on Windows), pick the right script for your OS, and update `settings.json`. Full step-by-step instructions Claude follows live in [INSTALL.md](INSTALL.md).
+Claude will clone the repo to that path, pick the right script for your OS, and update `settings.json`. Full step-by-step instructions Claude follows live in [INSTALL.md](INSTALL.md).
 
 Restart Claude Code after Claude saves the configuration.
 


### PR DESCRIPTION
## Summary

The README's suggested install prompt read *Clone ... and configure it as my status bar*, which left the target directory ambiguous. When a user copy-pastes that prompt, Claude Code has to guess where to clone — and it can easily pick the wrong place (e.g. a projects folder) instead of `~/.claude/statusline/`, where the rest of `INSTALL.md` assumes the repo lives.

## Code changes

- **`README.md`** — Update the suggested install prompt to include the target clone path (`~/.claude/statusline/`, or the Windows equivalent) and an explicit pointer to `INSTALL.md`. Trim the surrounding sentence since the path is no longer only mentioned there.

## How to test

1. Read the *Recommended: clone and let Claude configure it* section of `README.md`.
2. Confirm the suggested prompt now names the target path and references `INSTALL.md`.
3. (Optional) Hand the prompt to a fresh Claude Code session in a different working directory and verify it clones to `~/.claude/statusline/` rather than the cwd.