### PR TITLE
fix: clear empty version-cache lock when update fetch fails

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -441,7 +441,14 @@ if ($versionNeedsRefresh) {
             -Headers @{ "Accept" = "application/vnd.github+json" } -Method Get -TimeoutSec 5 -ErrorAction Stop
         $versionData = $vcResponse | ConvertTo-Json -Depth 10
         $versionData | Set-Content $versionCacheFile -Force
-    } catch {}
+    } catch {
+        # Fetch failed — if the cache has no usable content, drop the empty
+        # stampede lock so the next render retries instead of the fresh mtime
+        # suppressing update checks for the full 24h TTL.
+        if ((Test-Path $versionCacheFile) -and (Get-Item $versionCacheFile).Length -eq 0) {
+            Remove-Item $versionCacheFile -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 $updateLine = ""

--- a/statusline.sh
+++ b/statusline.sh
@@ -468,6 +468,11 @@ if $version_needs_refresh; then
     if [ -n "$vc_response" ] && echo "$vc_response" | jq -e '.tag_name' >/dev/null 2>&1; then
         version_data="$vc_response"
         echo "$vc_response" > "$version_cache_file"
+    elif [ ! -s "$version_cache_file" ]; then
+        # Fetch failed and the cache has no usable content — drop the empty
+        # stampede lock so the next render retries instead of the fresh mtime
+        # suppressing update checks for the full 24h TTL.
+        rm -f "$version_cache_file" 2>/dev/null
     fi
 fi
 


### PR DESCRIPTION
## Summary

The update-check code touches `statusline-version-cache.json` *before* calling the GitHub API as a stampede lock — so N concurrent status-line renders don't all fire the request in parallel. If the fetch fails (network blip, rate limit, 5-second timeout, or — as happened today — the first render that ran in the narrow window between deleting the cache and the release actually appearing on GitHub), the touched file stays on disk at **zero bytes with a fresh mtime**. The 24-hour TTL check then sees a "fresh" cache and suppresses every update check for a full day, even though no data was ever written.

## Code changes

- **`statusline.sh:463-477`** — After a failed `curl`, if the cache file is empty (`! -s`), `rm -f` it so the next render retries instead of waiting 24h.
- **`statusline.ps1:432-452`** — Mirror fix: in the `catch`, if the cache file exists and has `Length -eq 0`, `Remove-Item` it.

Success path is unchanged; if the cache pre-existed with valid content and the fetch fails, the old content is kept and reused (stale-but-usable fallback), retrying on the normal 24h boundary.

## How to test

1. Delete the cache file: `rm /tmp/claude/statusline-version-cache.json` (macOS/Linux) or the Windows equivalent under `$env:TEMP\claude\`.
2. Temporarily block the API (e.g. point to a bogus host in the script, or disconnect the network) and run the script once.
3. Confirm the cache file is **not** left behind as a zero-byte file.
4. Restore the API, run the script, confirm the cache fills normally and the `Update available: …` line surfaces when `VERSION` is behind the latest GitHub release.