### PR TITLE
feat: surface the exact Claude prompt in the update message

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Restart Claude Code after Claude saves the configuration.
 
 When the status line shows a new release is available, ask Claude:
 
-> Update my status bar.
+> Find my installed status bar and update it.
 
 Or update it yourself:
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -457,7 +457,7 @@ if ($versionData) {
         $vcParsed = if ($versionData -is [string]) { $versionData | ConvertFrom-Json } else { $versionData }
         $latestTag = $vcParsed.tag_name
         if ($latestTag -and (Test-VersionGreaterThan $latestTag $VERSION)) {
-            $updateLine = "`n${dim}Update available: ${latestTag} → https://github.com/daniel3303/ClaudeCodeStatusLine${reset}"
+            $updateLine = "`n${dim}Update available: ${latestTag} → Tell Claude: `"Find my installed status bar and update it`"${reset}"
         }
     } catch {}
 }

--- a/statusline.sh
+++ b/statusline.sh
@@ -480,7 +480,7 @@ update_line=""
 if [ -n "$version_data" ]; then
     latest_tag=$(echo "$version_data" | jq -r '.tag_name // empty')
     if [ -n "$latest_tag" ] && version_gt "$latest_tag" "$VERSION"; then
-        update_line="\n${dim}Update available: ${latest_tag} → https://github.com/daniel3303/ClaudeCodeStatusLine${reset}"
+        update_line="\n${dim}Update available: ${latest_tag} → Tell Claude: \"Find my installed status bar and update it\"${reset}"
     fi
 fi
 


### PR DESCRIPTION
## Summary

The `Update available: <tag>` line the status line prints when a new release is out previously trailed the repo URL. That is clickable but leaves the reader to figure out what to do next (clone? pull? paste?). Replace the URL with the exact Claude Code prompt to run, so a Pro/Max user can copy-paste straight into Claude and let it follow the documented update flow.

**Before**
```
Update available: v1.4.0 → https://github.com/daniel3303/ClaudeCodeStatusLine
```

**After**
```
Update available: v1.4.0 → Tell Claude: "Find my installed status bar and update it"
```

## Code changes

- **`statusline.sh:483`** — Replace the trailing URL with the Claude prompt.
- **`statusline.ps1:460`** — Same change, using PowerShell's backtick-escaped quotes.
- **`README.md:40`** — Align the "Updating" section's suggested prompt with the same wording the status line now surfaces, so the docs and the runtime message are consistent.

## How to test

1. Temporarily set `VERSION="1.0.0"` (or any value below the latest tag) in `statusline.sh` / `statusline.ps1`.
2. Clear the cache: `rm /tmp/claude/statusline-version-cache.json`.
3. Run the script with any valid stdin JSON and confirm the second line reads `Update available: <tag> → Tell Claude: "Find my installed status bar and update it"`.
4. Restore `VERSION`.