### PR TITLE
docs: drop paste-install alternative from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,10 @@ git -C ~/.claude/statusline pull
 
 No `settings.json` changes are needed — the path stays valid across versions.
 
-### Alternative: paste-install (no git required)
-
-If you can't clone (corporate-locked machine, no git, etc.), copy the contents of `statusline.sh` (macOS / Linux) or `statusline.ps1` (Windows) and paste it into Claude Code with:
-
-> Use this script as my status bar.
-
-Claude will save it under `~/.claude/` and wire up `settings.json`. Updating this way requires re-pasting the script on each release.
-
 ## Requirements
 
 - Claude Code with OAuth authentication (Pro/Max subscription for rate-limit and extra-usage data)
-- `git` in `PATH` (for the recommended install)
+- `git` in `PATH`
 - macOS / Linux: `jq` and `curl`
 - Windows: PowerShell 5.1+ (default on Windows 10/11)
 


### PR DESCRIPTION
## Summary

Remove the *Alternative: paste-install (no git required)* section from the README. The clone-based install is the only path the update-check flow and the runtime *Find my installed status bar and update it* Claude prompt rely on — advertising a paste path that skips `git pull` left users stranded on an older copy the next time the update line surfaced. Also drop the *(for the recommended install)* qualifier from the `git` requirement, which only made sense while a non-git alternative existed.

## Code changes

- **`README.md:50-56`** — Deleted the *Alternative: paste-install* section (heading, rationale, prompt, and follow-up paragraph).
- **`README.md:61`** — Simplified `git` requirement to just `git in PATH`.

## How to test

1. Open `README.md` on the PR.
2. Confirm the install section now has only the *Recommended: clone and let Claude configure it* flow and the *Updating* subsection.
3. Confirm the *Requirements* list reads `git in PATH` with no parenthetical.