### PR TITLE
docs: drop 'Recommended' subheading from install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Usage percentages are color-coded: green (<50%) → yellow (≥50%) → orange (
 
 ## Installation
 
-### Recommended: clone and let Claude configure it
-
 Ask Claude Code:
 
 > Clone https://github.com/daniel3303/ClaudeCodeStatusLine to `~/.claude/statusline/` (or `%USERPROFILE%\.claude\statusline\` on Windows) and configure it as my status bar by following its INSTALL.md.


### PR DESCRIPTION
## Summary

Follow-up to #33. The *Recommended: clone and let Claude configure it* h3 exists only because there used to be a second install path (paste-install) to be recommended over. With that alternative removed, the qualifier reads as leftover copy — there is only one install flow, so promote its content to sit directly under `## Installation`.

## Code changes

- **`README.md:26`** — Delete the `### Recommended: clone and let Claude configure it` heading. The intro sentence and prompt now hang directly off `## Installation`.

## How to test

1. Open `README.md` on the PR.
2. Confirm *Installation* has no *Recommended* subheading and flows straight into the `Ask Claude Code:` intro.
3. Confirm *Updating* is still the first (and only) h3 inside the install section.