### PR TITLE
fix: document -ExecutionPolicy Bypass and ~ path for Windows install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,29 +39,31 @@ Add (or update) the `statusLine` key in `~/.claude/settings.json` (Unix) or `%US
 }
 ```
 
-**Windows (PowerShell / CMD)**
+**Windows**
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "powershell -NoProfile -File \"%USERPROFILE%\\.claude\\statusline\\statusline.ps1\""
+    "command": "pwsh -NoProfile -ExecutionPolicy Bypass -File ~/.claude/statusline/statusline.ps1"
   }
 }
 ```
 
-**Windows (Git Bash / WSL bash shells)**
+If PowerShell 7+ (`pwsh`) is not installed, fall back to Windows PowerShell 5.1:
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "powershell -NoProfile -File \"$USERPROFILE\\.claude\\statusline\\statusline.ps1\""
+    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File ~/.claude/statusline/statusline.ps1"
   }
 }
 ```
 
-> `%VAR%` expands only in CMD/PowerShell; `$VAR` expands only in bash shells. Pick the one that matches the shell Claude Code launches the command in.
+> `-ExecutionPolicy Bypass` is **process-scoped** — it does not change your machine's PowerShell policy. Without it, a default `Restricted` or `AllSigned` policy (common on locked-down corporate machines) silently rejects the unsigned script and Claude Code shows no status line with no error.
+>
+> `~` is expanded by Claude Code v2.1.47+ on both Unix and Windows. On older Claude Code versions, replace `~/.claude/statusline/statusline.ps1` with `%USERPROFILE%\.claude\statusline\statusline.ps1` (CMD / PowerShell) or `$USERPROFILE\.claude\statusline\statusline.ps1` (Git Bash / WSL) — `%VAR%` expands only in CMD/PowerShell, `$VAR` only in bash shells.
 
 ## 4. Restart Claude Code
 


### PR DESCRIPTION
Closes #25.

## Summary

On a default Windows install, PowerShell's `ExecutionPolicy` is `Restricted` — and on corporate machines Group Policy frequently enforces `AllSigned`. The previous `"powershell -NoProfile -File ..."` command is refused with `UnauthorizedAccess` in both cases. Because Claude Code invokes the status line with stderr muted, the refusal is silent: no status line renders, no error surfaces, no hint points the user at the execution policy.

The reporter in #25 diagnosed this cleanly and provided a tested fix. Adopt it in `INSTALL.md`.

## Code changes

- **`INSTALL.md`** — Windows section
  - Add `-ExecutionPolicy Bypass` to the command. This is **process-scoped** — the machine's policy is untouched, but the unsigned `statusline.ps1` is allowed to run in this one invocation.
  - Lead with `pwsh` (PowerShell 7+, the actively developed cross-platform shell). Provide a documented fallback to Windows PowerShell 5.1 for users who have not installed PS7.
  - Replace `%USERPROFILE%\.claude\statusline\statusline.ps1` with `~/.claude/statusline/statusline.ps1`. Claude Code v2.1.47+ expands `~` on Windows, and the release notes explicitly recommend dropping `%USERPROFILE%`.
  - Collapse the separate *CMD/PowerShell* and *Git Bash / WSL* blocks — `~` works in both, so the split is no longer needed. Keep the legacy `%USERPROFILE%` / `$USERPROFILE` variants in a note for users still on older Claude Code builds.
  - Add a troubleshooting note explaining *why* `-ExecutionPolicy Bypass` is required, so the next user who hits a locked-down machine understands what the flag does and that it is safe.

## How to test

1. On a Windows 10/11 box with a default `Restricted` (or corporate `AllSigned`) ExecutionPolicy, follow the updated `INSTALL.md` Windows section.
2. Restart Claude Code.
3. Confirm the status line renders.
4. (Optional sanity check) run `Get-ExecutionPolicy -List` afterwards — the machine's policy should be unchanged; the bypass only applied to the status-line's `pwsh`/`powershell` process.