### PR TITLE
docs: surface INSTALL.md as the canonical install procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Usage percentages are color-coded: green (<50%) → yellow (≥50%) → orange (
 
 ## Installation
 
+The canonical install procedure — pick the right script for your OS, place it, wire up `settings.json` — lives in **[INSTALL.md](INSTALL.md)**. The one-line prompt below delegates that to Claude Code for you.
+
 Ask Claude Code:
 
 > Clone https://github.com/daniel3303/ClaudeCodeStatusLine to `~/.claude/statusline/` (or `%USERPROFILE%\.claude\statusline\` on Windows) and configure it as my status bar by following its INSTALL.md.
 
-Claude will clone the repo to that path, pick the right script for your OS, and update `settings.json`. Full step-by-step instructions Claude follows live in [INSTALL.md](INSTALL.md).
+Claude will clone the repo to that path, pick the right script for your OS, and update `settings.json`.
 
 Restart Claude Code after Claude saves the configuration.
 


### PR DESCRIPTION
## Summary

The `INSTALL.md` reference was buried in the middle of a sentence at the end of the install paragraph, so agents and humans skimming the README often missed that the step-by-step install lives in a dedicated file written to be followed verbatim. Promote it to a lead-in line under `## Installation` so the canonical procedure is the first thing a reader sees, and frame the Claude-prompt block explicitly as a delegation of that procedure.

## Code changes

- **`README.md:26`** — Added a lead-in sentence under `## Installation` that names `INSTALL.md` as the canonical install procedure.
- **`README.md:32`** — Dropped the trailing *Full step-by-step instructions Claude follows live in INSTALL.md* sentence now that the same pointer lives up top (avoids double-advertising the same file).

## How to test

1. Open `README.md` on the PR.
2. Confirm `## Installation` opens with a bolded `[INSTALL.md](INSTALL.md)` reference before the `Ask Claude Code:` prompt block.
3. Confirm the paragraph following the prompt no longer repeats the INSTALL.md link.