### PR TITLE
chore: release v1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,11 @@ Usage percentages are color-coded: green (<50%) → yellow (≥50%) → orange (
 
 ## Installation
 
-The canonical install procedure — pick the right script for your OS, place it, wire up `settings.json` — lives in **[INSTALL.md](INSTALL.md)**. The one-line prompt below delegates that to Claude Code for you.
-
 Ask Claude Code:
 
 > Clone https://github.com/daniel3303/ClaudeCodeStatusLine to `~/.claude/statusline/` (or `%USERPROFILE%\.claude\statusline\` on Windows) and configure it as my status bar by following its INSTALL.md.
 
-Claude will clone the repo to that path, pick the right script for your OS, and update `settings.json`.
+Claude will clone the repo to that path, pick the right script for your OS, and update `settings.json`. Full step-by-step instructions Claude follows live in [INSTALL.md](INSTALL.md).
 
 Restart Claude Code after Claude saves the configuration.
 


### PR DESCRIPTION
## Summary

Revert the README lead-in reference from #37 and bump the version to **1.4.2**. The lead-in reading *The canonical install procedure … lives in INSTALL.md. The one-line prompt below delegates that to Claude Code for you.* reframed the install section in a way that should go back to how it was; restore the v1.4.1 README wording and tag a clean build.

## Code changes

- **`README.md`** — Revert of e9bdc9b (the PR #37 lead-in). Install section goes back to the v1.4.1 layout: direct *Ask Claude Code:* block with the INSTALL.md reference inside the trailing paragraph.
- **`statusline.sh:6`** — `VERSION="1.4.1"` → `VERSION="1.4.2"`.
- **`statusline.ps1:3`** — `$VERSION = "1.4.1"` → `$VERSION = "1.4.2"`.

## How to test

1. Open `README.md` on the PR and confirm the install section matches v1.4.1 (no lead-in sentence, INSTALL.md only referenced inside the trailing paragraph).
2. `grep VERSION statusline.sh statusline.ps1` → both report `1.4.2`.
3. After merge, tag `v1.4.2` and release.