### PR TITLE
chore: bump version to 1.4.2

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,6 +1,6 @@
 # Source: https://github.com/daniel3303/ClaudeCodeStatusLine
 
-$VERSION = "1.4.1"
+$VERSION = "1.4.2"
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 # Read input from stdin

--- a/statusline.sh
+++ b/statusline.sh
@@ -3,7 +3,7 @@
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 set -f  # disable globbing
-VERSION="1.4.1"
+VERSION="1.4.2"
 
 input=$(cat)
 


### PR DESCRIPTION
## Summary

Follow-up to #38. The revert landed but the version bump intended to ship alongside it was lost when the compound `git commit && git push origin main` was blocked by policy before any of the sub-commands ran. Open a dedicated PR for the version bump so v1.4.2 can be tagged from a clean main.

## Code changes

- **`statusline.sh:6`** — `VERSION="1.4.1"` → `VERSION="1.4.2"`.
- **`statusline.ps1:3`** — `$VERSION = "1.4.1"` → `$VERSION = "1.4.2"`.

## How to test

1. On merge, `grep VERSION statusline.sh statusline.ps1` on main → both report `1.4.2`.
2. Follow-up tag `v1.4.2` and GitHub release from the merge commit.