### PR TITLE
Show weekday in weekly reset time

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -285,7 +285,7 @@ function Format-ResetTime([string]$isoStr, [string]$style) {
         $dt = [DateTimeOffset]::Parse($isoStr).LocalDateTime
         switch ($style) {
             "time"     { return $dt.ToString("h:mmtt").ToLower() }
-            "datetime" { return $dt.ToString("MMM d, h:mmtt").ToLower() }
+            "datetime" { return $dt.ToString("ddd MMM d, h:mmtt").ToLower() }
             default    { return $dt.ToString("MMM d").ToLower() }
         }
     } catch { return $null }
@@ -298,7 +298,7 @@ function Format-EpochResetTime([object]$epoch, [string]$style) {
         $dt = [DateTimeOffset]::FromUnixTimeSeconds([long]$epoch).LocalDateTime
         switch ($style) {
             "time"     { return $dt.ToString("h:mmtt").ToLower() }
-            "datetime" { return $dt.ToString("MMM d, h:mmtt").ToLower() }
+            "datetime" { return $dt.ToString("ddd MMM d, h:mmtt").ToLower() }
             default    { return $dt.ToString("MMM d").ToLower() }
         }
     } catch { return $null }

--- a/statusline.sh
+++ b/statusline.sh
@@ -333,8 +333,8 @@ format_reset_time() {
             formatted=$(date -j -r "$epoch" +"%H:%M" 2>/dev/null)
             ;;
         datetime)
-            formatted=$(date -d "@$epoch" +"%b %-d, %H:%M" 2>/dev/null) || \
-            formatted=$(date -j -r "$epoch" +"%b %-d, %H:%M" 2>/dev/null)
+            formatted=$(date -d "@$epoch" +"%a %b %-d, %H:%M" 2>/dev/null) || \
+            formatted=$(date -j -r "$epoch" +"%a %b %-d, %H:%M" 2>/dev/null)
             ;;
         *)
             formatted=$(date -d "@$epoch" +"%b %-d" 2>/dev/null) || \
@@ -387,7 +387,7 @@ if $effective_builtin; then
         seven_day_color=$(usage_color "$seven_day_pct")
         out+="${sep}${white}7d${reset} ${seven_day_color}${seven_day_pct}%${reset}"
         if [ -n "$builtin_seven_day_reset" ] && [ "$builtin_seven_day_reset" != "null" ]; then
-            seven_day_reset=$(date -j -r "$builtin_seven_day_reset" +"%b %-d, %H:%M" 2>/dev/null || date -d "@$builtin_seven_day_reset" +"%b %-d, %H:%M" 2>/dev/null)
+            seven_day_reset=$(date -j -r "$builtin_seven_day_reset" +"%a %b %-d, %H:%M" 2>/dev/null || date -d "@$builtin_seven_day_reset" +"%a %b %-d, %H:%M" 2>/dev/null)
             [ -n "$seven_day_reset" ] && out+=" ${dim}@${seven_day_reset}${reset}"
         fi
     fi


### PR DESCRIPTION
Summary:

Adds the abbreviated weekday to the 7-day reset timestamp.

Before:

`7d 31% @Apr 26, 19:00`

After:

`7d 31% @Sun Apr 26, 19:00`

Notes:

This keeps the existing compact format while making the weekly reset easier to interpret at a glance.

Testing:

- Ran `bash -n statusline.sh`
- Ran PowerShell validation if `pwsh` was available
- Verified the seven-day reset datetime format now includes the abbreviated weekday
