### PR TITLE
fix: read live effort level from stdin JSON (effort.level)

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -98,9 +98,10 @@ $remainComma = Format-Commas ($size - $current)
 # Config directory (respects CLAUDE_CONFIG_DIR override)
 $claudeConfigDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE ".claude" }
 
-# Check reasoning effort
-$effortLevel = "medium"
-if ($env:CLAUDE_CODE_EFFORT_LEVEL) {
+$effortLevel = $null
+if ($data.effort.level) {
+    $effortLevel = [string]$data.effort.level
+} elseif ($env:CLAUDE_CODE_EFFORT_LEVEL) {
     $effortLevel = $env:CLAUDE_CODE_EFFORT_LEVEL
 } else {
     $settingsPath = Join-Path $claudeConfigDir "settings.json"
@@ -111,6 +112,7 @@ if ($env:CLAUDE_CODE_EFFORT_LEVEL) {
         } catch {}
     }
 }
+if (-not $effortLevel) { $effortLevel = "medium" }
 
 # ===== Build single-line output =====
 $out = ""

--- a/statusline.sh
+++ b/statusline.sh
@@ -97,15 +97,18 @@ pct_remain=$(( 100 - pct_used ))
 used_comma=$(format_commas $current)
 remain_comma=$(format_commas $(( size - current )))
 
-# Check reasoning effort
 settings_path="$claude_config_dir/settings.json"
-effort_level="medium"
-if [ -n "$CLAUDE_CODE_EFFORT_LEVEL" ]; then
+effort_level=""
+stdin_effort=$(echo "$input" | jq -r '.effort.level // empty' 2>/dev/null)
+if [ -n "$stdin_effort" ]; then
+    effort_level="$stdin_effort"
+elif [ -n "$CLAUDE_CODE_EFFORT_LEVEL" ]; then
     effort_level="$CLAUDE_CODE_EFFORT_LEVEL"
 elif [ -f "$settings_path" ]; then
     effort_val=$(jq -r '.effortLevel // empty' "$settings_path" 2>/dev/null)
     [ -n "$effort_val" ] && effort_level="$effort_val"
 fi
+[ -z "$effort_level" ] && effort_level="medium"
 
 # ===== Build single-line output =====
 out=""


### PR DESCRIPTION
## Problem

The statusline currently resolves the reasoning-effort label from two
sources only:

1. `CLAUDE_CODE_EFFORT_LEVEL` environment variable.
2. `effortLevel` in `settings.json`.

Neither is updated when the user changes effort with the in-session
`/effort <level>` slash command. After running `/effort max`, the
statusline keeps rendering the previously persisted value (e.g.
`xhigh`) until the next process restart and `settings.json` edit.

## Fix

Claude Code already pipes the live effort to the statusline command
under `effort.level` in the stdin JSON (see the official statusline
schema: <https://code.claude.com/docs/en/statusline.md#available-data>).

Prefer that field on both the Bash and PowerShell entrypoints, then
fall back through the existing chain so behaviour is unchanged when the
field is absent (older Claude Code versions or models without an
effort parameter):

```
stdin .effort.level
  → CLAUDE_CODE_EFFORT_LEVEL
  → settings.json effortLevel
  → "medium"
```

## Changes

- `statusline.sh` — read `.effort.level` via `jq` before consulting env
  and settings.
- `statusline.ps1` — same priority order using `$data.effort.level`.

No new dependencies; both scripts already use `jq` / `ConvertFrom-Json`
for other fields.

## Verification

PowerShell, on Windows 11:

```powershell
$json = '{"model":{"display_name":"Opus"},"cwd":"C:/x","effort":{"level":"max"},"context_window":{"context_window_size":200000,"current_usage":{"input_tokens":1000}}}'
$json | powershell -NoProfile -ExecutionPolicy Bypass -File statusline.ps1
# … effort: max …  (red, as expected)
```

Removing `effort` from the JSON falls back to `settings.json`'s
`effortLevel` (verified: still renders `xhigh`).

The Bash variant mirrors the PowerShell logic line-for-line and uses
the same `jq` invocation pattern as the rest of the file.