### PR TITLE
chore: bump version to 1.4.3

### DIFF
--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,6 +1,6 @@
 # Source: https://github.com/daniel3303/ClaudeCodeStatusLine
 
-$VERSION = "1.4.2"
+$VERSION = "1.4.3"
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 # Read input from stdin

--- a/statusline.sh
+++ b/statusline.sh
@@ -3,7 +3,7 @@
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 set -f  # disable globbing
-VERSION="1.4.2"
+VERSION="1.4.3"
 
 input=$(cat)
 


### PR DESCRIPTION
## Summary

Bumps version from 1.4.2 → 1.4.3 to reflect the live effort-level fix merged in #42.

## Code changes

- `statusline.sh` — `VERSION="1.4.3"`
- `statusline.ps1` — `$VERSION = "1.4.3"`

## How to test

```bash
grep '^VERSION=' statusline.sh    # → VERSION="1.4.3"
grep '^\$VERSION' statusline.ps1  # → $VERSION = "1.4.3"
```

Self-update check in the statusline will now match the new tag once released.