### PR TITLE
feat: add opt-out for update check via STATUSLINE_CHECK_UPDATES

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ Usage data from the Anthropic API is cached for 60 seconds at `/tmp/claude/statu
 
 ## Update Notifications
 
-The status line checks GitHub for new releases once every 24 hours. When a newer version is available, a second line appears below the status line. The check fails silently if the API is unreachable.
+The status line checks GitHub for new releases once every 24 hours via an outbound HTTP request to `api.github.com`. When a newer version is available, a second line appears below the status line. The check fails silently if the API is unreachable.
+
+To disable the update check entirely (no network calls):
+
+```bash
+export STATUSLINE_CHECK_UPDATES=false
+```
 
 ## License
 

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,6 +1,6 @@
 # Source: https://github.com/daniel3303/ClaudeCodeStatusLine
 
-$VERSION = "1.4.3"
+$VERSION = "1.4.4"
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 # Read input from stdin
@@ -443,52 +443,51 @@ if ($effectiveBuiltin) {
 }
 
 # ===== Update check (cached, 24h TTL) =====
-$versionCacheFile = Join-Path $cacheDir "statusline-version-cache.json"
-$versionCacheMaxAge = 86400  # 24 hours
-
-$versionNeedsRefresh = $true
-$versionData = $null
-
-if (Test-Path $versionCacheFile) {
-    $vcMtime = (Get-Item $versionCacheFile).LastWriteTime
-    $vcAge = ((Get-Date) - $vcMtime).TotalSeconds
-    if ($vcAge -lt $versionCacheMaxAge) {
-        $versionNeedsRefresh = $false
-    }
-    $versionData = Get-Content $versionCacheFile -Raw
-}
-
-if ($versionNeedsRefresh) {
-    # Touch cache immediately (thundering herd protection)
-    if (Test-Path $versionCacheFile) {
-        (Get-Item $versionCacheFile).LastWriteTime = Get-Date
-    } else {
-        New-Item -ItemType File -Path $versionCacheFile -Force | Out-Null
-    }
-    try {
-        $vcResponse = Invoke-RestMethod -Uri "https://api.github.com/repos/daniel3303/ClaudeCodeStatusLine/releases/latest" `
-            -Headers @{ "Accept" = "application/vnd.github+json" } -Method Get -TimeoutSec 5 -ErrorAction Stop
-        $versionData = $vcResponse | ConvertTo-Json -Depth 10
-        $versionData | Set-Content $versionCacheFile -Force
-    } catch {
-        # Fetch failed — if the cache has no usable content, drop the empty
-        # stampede lock so the next render retries instead of the fresh mtime
-        # suppressing update checks for the full 24h TTL.
-        if ((Test-Path $versionCacheFile) -and (Get-Item $versionCacheFile).Length -eq 0) {
-            Remove-Item $versionCacheFile -Force -ErrorAction SilentlyContinue
-        }
-    }
-}
-
+# Set STATUSLINE_CHECK_UPDATES=false to disable the update check (no network calls).
 $updateLine = ""
-if ($versionData) {
-    try {
-        $vcParsed = if ($versionData -is [string]) { $versionData | ConvertFrom-Json } else { $versionData }
-        $latestTag = $vcParsed.tag_name
-        if ($latestTag -and (Test-VersionGreaterThan $latestTag $VERSION)) {
-            $updateLine = "`n${dim}Update available: ${latestTag} → Tell Claude: `"Find my installed status bar and update it`"${reset}"
+if ($env:STATUSLINE_CHECK_UPDATES -ne "false") {
+    $versionCacheFile = Join-Path $cacheDir "statusline-version-cache.json"
+    $versionCacheMaxAge = 86400  # 24 hours
+
+    $versionNeedsRefresh = $true
+    $versionData = $null
+
+    if (Test-Path $versionCacheFile) {
+        $vcMtime = (Get-Item $versionCacheFile).LastWriteTime
+        $vcAge = ((Get-Date) - $vcMtime).TotalSeconds
+        if ($vcAge -lt $versionCacheMaxAge) {
+            $versionNeedsRefresh = $false
         }
-    } catch {}
+        $versionData = Get-Content $versionCacheFile -Raw
+    }
+
+    if ($versionNeedsRefresh) {
+        if (Test-Path $versionCacheFile) {
+            (Get-Item $versionCacheFile).LastWriteTime = Get-Date
+        } else {
+            New-Item -ItemType File -Path $versionCacheFile -Force | Out-Null
+        }
+        try {
+            $vcResponse = Invoke-RestMethod -Uri "https://api.github.com/repos/daniel3303/ClaudeCodeStatusLine/releases/latest" `
+                -Headers @{ "Accept" = "application/vnd.github+json" } -Method Get -TimeoutSec 5 -ErrorAction Stop
+            $versionData = $vcResponse | ConvertTo-Json -Depth 10
+            $versionData | Set-Content $versionCacheFile -Force
+        } catch {
+            if ((Test-Path $versionCacheFile) -and (Get-Item $versionCacheFile).Length -eq 0) {
+                Remove-Item $versionCacheFile -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    if ($versionData) {
+        try {
+            $vcParsed = if ($versionData -is [string]) { $versionData | ConvertFrom-Json } else { $versionData }
+            $latestTag = $vcParsed.tag_name
+            if ($latestTag -and (Test-VersionGreaterThan $latestTag $VERSION)) {
+                $updateLine = "`n${dim}Update available: ${latestTag} → Tell Claude: `"Find my installed status bar and update it`"${reset}"
+            }
+        } catch {}
+    }
 }
 
 # Append CLI version as last segment

--- a/statusline.sh
+++ b/statusline.sh
@@ -3,7 +3,7 @@
 # Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
 
 set -f  # disable globbing
-VERSION="1.4.3"
+VERSION="1.4.4"
 
 input=$(cat)
 
@@ -469,43 +469,43 @@ else
 fi
 
 # ===== Update check (cached, 24h TTL) =====
-version_cache_file="/tmp/claude/statusline-version-cache.json"
-version_cache_max_age=86400  # 24 hours
-
-version_needs_refresh=true
-version_data=""
-
-if [ -f "$version_cache_file" ]; then
-    vc_mtime=$(stat -c %Y "$version_cache_file" 2>/dev/null || stat -f %m "$version_cache_file" 2>/dev/null)
-    vc_now=$(date +%s)
-    vc_age=$(( vc_now - vc_mtime ))
-    if [ "$vc_age" -lt "$version_cache_max_age" ]; then
-        version_needs_refresh=false
-    fi
-    version_data=$(cat "$version_cache_file" 2>/dev/null)
-fi
-
-if $version_needs_refresh; then
-    touch "$version_cache_file" 2>/dev/null
-    vc_response=$(curl -s --max-time 5 \
-        -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/daniel3303/ClaudeCodeStatusLine/releases/latest" 2>/dev/null)
-    if [ -n "$vc_response" ] && echo "$vc_response" | jq -e '.tag_name' >/dev/null 2>&1; then
-        version_data="$vc_response"
-        echo "$vc_response" > "$version_cache_file"
-    elif [ ! -s "$version_cache_file" ]; then
-        # Fetch failed and the cache has no usable content — drop the empty
-        # stampede lock so the next render retries instead of the fresh mtime
-        # suppressing update checks for the full 24h TTL.
-        rm -f "$version_cache_file" 2>/dev/null
-    fi
-fi
-
+# Set STATUSLINE_CHECK_UPDATES=false to disable the update check (no network calls).
 update_line=""
-if [ -n "$version_data" ]; then
-    latest_tag=$(echo "$version_data" | jq -r '.tag_name // empty')
-    if [ -n "$latest_tag" ] && version_gt "$latest_tag" "$VERSION"; then
-        update_line="\n${dim}Update available: ${latest_tag} → Tell Claude: \"Find my installed status bar and update it\"${reset}"
+if [ "${STATUSLINE_CHECK_UPDATES:-true}" != "false" ]; then
+    version_cache_file="/tmp/claude/statusline-version-cache.json"
+    version_cache_max_age=86400  # 24 hours
+
+    version_needs_refresh=true
+    version_data=""
+
+    if [ -f "$version_cache_file" ]; then
+        vc_mtime=$(stat -c %Y "$version_cache_file" 2>/dev/null || stat -f %m "$version_cache_file" 2>/dev/null)
+        vc_now=$(date +%s)
+        vc_age=$(( vc_now - vc_mtime ))
+        if [ "$vc_age" -lt "$version_cache_max_age" ]; then
+            version_needs_refresh=false
+        fi
+        version_data=$(cat "$version_cache_file" 2>/dev/null)
+    fi
+
+    if $version_needs_refresh; then
+        touch "$version_cache_file" 2>/dev/null
+        vc_response=$(curl -s --max-time 5 \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/daniel3303/ClaudeCodeStatusLine/releases/latest" 2>/dev/null)
+        if [ -n "$vc_response" ] && echo "$vc_response" | jq -e '.tag_name' >/dev/null 2>&1; then
+            version_data="$vc_response"
+            echo "$vc_response" > "$version_cache_file"
+        elif [ ! -s "$version_cache_file" ]; then
+            rm -f "$version_cache_file" 2>/dev/null
+        fi
+    fi
+
+    if [ -n "$version_data" ]; then
+        latest_tag=$(echo "$version_data" | jq -r '.tag_name // empty')
+        if [ -n "$latest_tag" ] && version_gt "$latest_tag" "$VERSION"; then
+            update_line="\n${dim}Update available: ${latest_tag} → Tell Claude: \"Find my installed status bar and update it\"${reset}"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Adds `STATUSLINE_CHECK_UPDATES=false` env var to disable the 24h version check entirely (no outbound network calls).
- Update check remains **enabled by default** — this is an opt-out, not opt-in.
- README updated to document the env var and clarify that the check makes an HTTP request to `api.github.com`.

## Code changes

- `statusline.sh`: wrapped version-check block in env var guard
- `statusline.ps1`: same guard using `$env:STATUSLINE_CHECK_UPDATES`
- `README.md`: expanded "Update Notifications" section with opt-out instructions
- Version bumped to 1.4.4

Closes #40